### PR TITLE
update: やることリストからの再出品バグ修正

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release:
     permissions:
-      # github リリースを作成するには書き込み権限が必要です。
+      # github リリースを作成するには書き込み権限が必要です
       contents: write
       # リリースノートを書くためwrite用のpermissionを付与
       pull-requests: write

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ class GUI:
         return layout
 
     def start_selected_program(self, program_name, count):
-        """GUIで選択されたプログラムを実行する。"""
+        """GUIで選択されたプログラムを実行する"""
         if program_name == "自動再出品":
             auto_relist = AutoRelist()
             auto_relist.run(count)
@@ -53,7 +53,7 @@ class GUI:
                         count = int(count_str)
                         self.start_selected_program(program_name, count)
                 else:
-                    pgui.alert("件数には数字を入力してください。", title="入力エラー")
+                    pgui.alert("件数には数字を入力してください", title="入力エラー")
         window.close()
 
 

--- a/src/modules/screen.py
+++ b/src/modules/screen.py
@@ -13,21 +13,13 @@ class ScreenManagement():
             pgui.press("F5")
             time.sleep(wait_time)
 
-    def image_locate(self, image_path: str) -> tuple:
+    def image_locate(self, image_path: str, confidence=0.7):
         """
         Webページ内に該当する画像を認識し、その座標を返す
-        そもそも間違った画像だったら例外を吐く
+
+        画像が存在しない場合は`ImageNotFoundException`が発生するので、キャッチしてNoneを返す
         """
-        locate = pgui.locateOnScreen(image_path, grayscale=True, confidence=0.7)
-        if not locate:
-            raise pgui.ImageNotFoundException
-
-        return locate
-
-    def check_page(self, image_path: str):
-        """指定した画像が画面上に存在するか確認する"""
         try:
-            is_image = pgui.locateOnScreen(image_path, grayscale=True, confidence=0.7) is not None
-            return is_image
+            return pgui.locateOnScreen(image_path, grayscale=True, confidence=confidence)
         except pgui.ImageNotFoundException:
-            return False
+            return None

--- a/src/scripts/auto_relist_sold_items.py
+++ b/src/scripts/auto_relist_sold_items.py
@@ -1,9 +1,5 @@
 from .base_script import BaseScript
-from modules.logger import Logger
-from modules.screen import ScreenManagement
-from modules.web_manager import WebManager
 import pyautogui as pgui
-import time
 
 
 class AutoRelistSoldItems(BaseScript):
@@ -11,51 +7,28 @@ class AutoRelistSoldItems(BaseScript):
 
     def __init__(self):
         super().__init__()
-        self.logger = Logger.setup_logger("auto_relist_sold_items")
-        self.screen = ScreenManagement()
-        self.web = WebManager()
         self.logger.info("売れた商品の自動再出品を開始します")
 
-    def run(self, count=1, retry_limit=3):
+    def run(self, count=1):
         self.logger.info("---------------start---------------")
         for _ in range(count):
             current_url = self.web.get_url()
             self.web.go_product_page(current_url)
+            self.logger.info(f"この商品を再出品します。商品URL: {current_url}")
 
-            self.logger.info(f"この商品を再出品します。商品URL: {self.web.get_url()}")
-            try:
-                mercari_copy_image: tuple = self.screen.image_locate(image_path="./images/mercari_copy.png")
-                pgui.click(mercari_copy_image, duration=0.5)
-                self.logger.info("画像あり再出品を選択")
-                time.sleep(17)
-            except Exception as e:
-                self.logger.error(e)
-                self.logger.error("画像あり再出品を選択できませんでした。処理を終了します。")
+            # 画像あり再出品を押下する
+            is_relist = self.start_relisting(image_path="./images/mercari_copy.png")
+            if is_relist is False:
                 break
-
-            # 出品するボタンを押すために画面一番下へスクロール
-            for attempt in range(retry_limit):
-                pgui.press("end")
-                time.sleep(2)
-                try:
-                    relist_image: tuple = self.screen.image_locate(image_path="./images/syuppinnsuru.png")
-                    pgui.click(relist_image, duration=0.5)
-                    self.logger.info("出品するボタンを押下")
-                    time.sleep(2)
-                    break  # 成功した場合、ループを抜ける
-                except pgui.ImageNotFoundException as e:
-                    self.logger.error(f"出品するボタンが見つかりません。リトライ {attempt + 1}/{retry_limit}")
-                    if attempt == retry_limit - 1:
-                        self.logger.error("リトライの上限に達しました。処理を終了します。")
-                        raise e
-                    time.sleep(1)  # リトライ間の待機時間
-
-            # 出品が完了しているか確認
-            fix_relist_check1 = self.screen.check_page(image_path="./images/syuppindekiteiruka.png")
-            fix_relist_check2 = self.screen.check_page(image_path="./images/kakakuwokimezunisyuppin.png")
-            # 出品が完了しているか確認
-            if fix_relist_check1 and fix_relist_check2 == False:
-                self.logger.error("出品が完了していません。処理を終了します。")
+            
+            # 商品ページで出品するを押下する
+            is_relist_button_clicked = self.scroll_to_bottom_and_click(image_path="./images/syuppinnsuru.png")
+            if is_relist_button_clicked is False:
+                break
+            
+            # 出品するボタンを押下したあと、出品が完了できているか確認する
+            is_fix_relist = self.check_relist()
+            if is_fix_relist is False:
                 break
 
             pgui.hotkey("ctrl", "w")

--- a/src/scripts/auto_relist_sold_items.py
+++ b/src/scripts/auto_relist_sold_items.py
@@ -14,10 +14,10 @@ class AutoRelistSoldItems(BaseScript):
         for _ in range(count):
             current_url = self.web.get_url()
             self.web.go_product_page(current_url)
-            self.logger.info(f"この商品を再出品します。商品URL: {current_url}")
+            self.logger.info(f"この商品を再出品します商品URL: {current_url}")
 
             # 画像あり再出品を押下する
-            is_relist = self.start_relisting(image_path="./images/mercari_copy.png")
+            is_relist = self.click_and_wait(image_path="./images/mercari_copy.png")
             if is_relist is False:
                 break
             
@@ -32,7 +32,7 @@ class AutoRelistSoldItems(BaseScript):
                 break
 
             pgui.hotkey("ctrl", "w")
-            self.logger.info("出品が完了したため、次の商品を再出品します。")
+            self.logger.info("出品が完了したため、次の商品を再出品します")
         self.logger.info("売れた商品の自動再出品を終了します")
         self.logger.info("----------------end----------------")
         pgui.alert(text="売れた商品の自動再出品を終了します", title="終了通知", button="OK")

--- a/src/scripts/base_script.py
+++ b/src/scripts/base_script.py
@@ -22,19 +22,18 @@ class BaseScript:
         if src_dir not in sys.path:
             sys.path.append(src_dir)
 
-    def start_relisting(self, image_path: str, sleep_time=17):
+    def click_and_wait(self, image_path: str, sleep_time=17):
         """
-        画像あり再出品を実施する
+        指定した座標を押下して、押下後に指定した秒数待機する
+        初期値は画像あり再出品で使用する17秒を指定
         """
         try:
-            mercari_copy_image: tuple = self.screen.image_locate(image_path=image_path)
-            pgui.click(mercari_copy_image, duration=0.5)
-            self.logger.info("画像あり再出品を選択しました。")
+            click_image: tuple = self.screen.image_locate(image_path=image_path)
+            pgui.click(click_image, duration=0.5)
             time.sleep(sleep_time)
             return True
         except Exception as e:
             self.logger.error(e)
-            self.logger.error("画像あり再出品を選択できませんでした。処理を終了します。")
             return False
 
     def scroll_to_bottom_and_click(self, image_path, retry_limit=3):
@@ -53,9 +52,9 @@ class BaseScript:
                 time.sleep(2)
                 return True
             except pgui.ImageNotFoundException:
-                self.logger.error(f"出品するボタンが見つかりません。リトライ {attempt + 1}/{retry_limit}")
+                self.logger.error(f"出品するボタンが見つかりませんリトライ {attempt + 1}/{retry_limit}")
                 if attempt == retry_limit - 1:
-                    self.logger.error("リトライの上限に達しました。処理を終了します。")
+                    self.logger.error("リトライの上限に達しました処理を終了します")
                     return False
         return False
 
@@ -68,6 +67,6 @@ class BaseScript:
 
         # 出品が完了しているか確認
         if fix_relist_check1 and fix_relist_check2 == None:
-            self.logger.error("出品が完了していません。処理を終了します。")
+            self.logger.error("出品が完了していません処理を終了します")
             return False
         return True

--- a/src/scripts/base_script.py
+++ b/src/scripts/base_script.py
@@ -1,12 +1,19 @@
+from modules.logger import Logger
+from modules.screen import ScreenManagement
+from modules.web_manager import WebManager
+import pyautogui as pgui
+import time
 import os
 import sys
-
 
 class BaseScript:
     """実行ファイルが格納されているフォルダのベースクラス"""
 
     def __init__(self):
         self.setup_path()
+        self.logger = Logger.setup_logger("auto-relist")
+        self.screen = ScreenManagement()
+        self.web = WebManager()
 
     def setup_path(self):
         """スクリプトごとにモジュールパスを設定する"""
@@ -14,3 +21,53 @@ class BaseScript:
         src_dir = os.path.abspath(os.path.join(current_dir, ".."))
         if src_dir not in sys.path:
             sys.path.append(src_dir)
+
+    def start_relisting(self, image_path: str, sleep_time=17):
+        """
+        画像あり再出品を実施する
+        """
+        try:
+            mercari_copy_image: tuple = self.screen.image_locate(image_path=image_path)
+            pgui.click(mercari_copy_image, duration=0.5)
+            self.logger.info("画像あり再出品を選択しました。")
+            time.sleep(sleep_time)
+            return True
+        except Exception as e:
+            self.logger.error(e)
+            self.logger.error("画像あり再出品を選択できませんでした。処理を終了します。")
+            return False
+
+    def scroll_to_bottom_and_click(self, image_path, retry_limit=3):
+        """
+        出品するボタンを押下する
+        押す前に出品するボタンが見つかるまで画面一番下までスクロールする
+        """
+        # 出品するボタンを押すために画面一番下へスクロール
+        for attempt in range(retry_limit):
+            pgui.press("end")
+            time.sleep(2)
+            try:
+                relist_image: tuple = self.screen.image_locate(image_path=image_path)
+                pgui.click(relist_image, duration=0.5)
+                self.logger.info("出品するボタンを押下")
+                time.sleep(2)
+                return True
+            except pgui.ImageNotFoundException:
+                self.logger.error(f"出品するボタンが見つかりません。リトライ {attempt + 1}/{retry_limit}")
+                if attempt == retry_limit - 1:
+                    self.logger.error("リトライの上限に達しました。処理を終了します。")
+                    return False
+        return False
+
+    def check_relist(self):
+        """
+        出品するボタンを押下したあと、出品が完了できているか確認する
+        """
+        fix_relist_check1 = self.screen.image_locate(image_path="./images/syuppindekiteiruka.png")
+        fix_relist_check2 = self.screen.image_locate(image_path="./images/kakakuwokimezunisyuppin.png")
+
+        # 出品が完了しているか確認
+        if fix_relist_check1 and fix_relist_check2 == None:
+            self.logger.error("出品が完了していません。処理を終了します。")
+            return False
+        return True

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -20,56 +20,20 @@ def create_alert():
     # ここでテストの前提条件を設定します
     pgui.alert(text="ボタンを押したらテストが始まります", title="テスト用の待機時間", button="OK")
     logger = Logger.setup_logger("__test__")
-    logger.info("テストを開始します")
+    logger.info(f"{__name__}のテストを開始します")
 
     time.sleep(1)
 
 
 # 画像認識のテストケースを含むテストクラス
 class TestScreenManagement:
-    @pytest.mark.skip(reason="一度実行したためスキップ")
-    @pytest.mark.usefixtures("create_alert")
-    def test_reloading_page(self):
-        """画像が読み込めなかったとき正常にリロードするか"""
-        result = screen_manager.reloading_page(None, wait_time=0)
-        assert result is None
-
-    @pytest.mark.skip(reason="一度実行したためスキップ")
+    @pytest.mark.skip(reason="2024/08/11")
     @pytest.mark.usefixtures("create_alert")
     def test_image_locate(self):
-        # 画像を認識して座標を取得
-        result = screen_manager.image_locate("./images/syuppinnsuru.png")
-        print(result)
+        # 画像を認識して座標を取得する
+        result = screen_manager.image_locate("./images/mercari_copy.png")
         assert result is not None
 
-    # 存在しない画像をエラー吐くかのテスト
-    @pytest.mark.skip(reason="一度実行したためスキップ")
-    @pytest.mark.usefixtures("create_alert")
-    def test_image_locate(self):
-        with pytest.raises(pgui.ImageNotFoundException):
-            # 画像が存在しない場合、pgui.ImageNotFoundException が発生することを確認
-            screen_manager.image_locate("./images/syuppinnsyouhinwomiru.png")
-
-    # ページの存在確認のテスト
-    @pytest.mark.skip(reason="一度実行したためスキップ")
-    @pytest.mark.usefixtures("create_alert")
-    def test_check_page(self):
-        # 画像が画面上に存在するか確認
-        # 商品の編集をするページが存在するか確認
-        result = screen_manager.check_page("./images/syouhinnnohensyuu.png")
-        assert result is True
-
-    # ページの存在確認のテスト
-    @pytest.mark.skip(reason="一度実行したためスキップ")
-    @pytest.mark.usefixtures("create_alert")
-    def test_time_sale_check_page(self):
-        # タイムセールページが存在するか確認
-        result = screen_manager.check_page("./images/time-sale-or-syouhinnohensyu.png")
-        assert result is True
-
-    # ページの存在確認のテスト
-    @pytest.mark.usefixtures("create_alert")
-    def test_price_ok_check_page(self):
-        # タイムセールページが存在するか確認
-        result = screen_manager.check_page("./images/time-sale-or-syouhinnohensyu.png")
-        assert result is True
+        # 画像が存在しない場合はNoneを返す
+        result2 = screen_manager.image_locate("./images/syuppindekiteiruka.png")
+        assert result2 is None


### PR DESCRIPTION
共通処理をまとめた。

エラー時は基本的にFalseを返すようにして、実行メソッド内でエラーハンドリングするように修正(`run()`メソッド) #10 